### PR TITLE
Fix/table with builtin names

### DIFF
--- a/nagra/select.py
+++ b/nagra/select.py
@@ -23,7 +23,7 @@ def clean_col(name):
 class Select:
     def __init__(self, table, *columns: str, trn: "Transaction", env: "Env"):
         self.table = table
-        self.env = env  # Env(table)
+        self.env = env
         self.where_asts = tuple()
         self._offset = None
         self._limit = None

--- a/nagra/sexpr.py
+++ b/nagra/sexpr.py
@@ -67,8 +67,11 @@ class Alias:
 def tokenize(expr):
     lexer = shlex.shlex(expr)
     lexer.wordchars += ".!=<>:{}-|"
+    prev_tk = None
     for i in lexer:
-        yield Token.from_value(i)
+        tk = Token.from_value(i, prev_tk)
+        prev_tk = tk
+        yield tk
 
 
 def scan(tokens, end_tk=")"):
@@ -100,8 +103,6 @@ class AST:
         "or": lambda *x: " OR ".join(x),
         "not": "NOT {}".format,
         "is": "{} is {}".format,
-        "true": lambda: "true",
-        "false": lambda: "false",
         # Arithmetic
         "+": lambda *xs: " + ".join(map(str, xs)),
         "-": (lambda *xs: " - ".join(map(str, xs)) if len(xs) > 1 else f"-{xs[0]}"),
@@ -116,6 +117,12 @@ class AST:
         "||": lambda *xs: " || ".join(map(str, xs)),
         # Others
         "in": lambda x, *ys: f"{x} in (%s)" % ", ".join(map(str, ys)),
+        "var": lambda x: x
+    }
+
+    literals = {
+        "true": lambda: "true",
+        "false": lambda: "false",
         "null": lambda: "NULL",
     }
 
@@ -202,11 +209,26 @@ class Token:
         return False
 
     @staticmethod
-    def from_value(value):
-        if value in AST.builtins:
-            return BuiltinToken(value)
-        if value in AST.aggregates:
-            return AggToken(value)
+    def from_value(value, prev_tk):
+        # Handle exceptions
+        if value == "(":
+            return LParen(value)
+
+        # Literals take precedence over everything except
+        # when following a var operator
+        is_prev_var_op = prev_tk and prev_tk.is_var_op
+        if not is_prev_var_op and value in AST.literals:
+            return LiteralToken(value)
+
+        # First item should be an operator
+        if isinstance(prev_tk, LParen):
+            if value in AST.builtins:
+                return BuiltinToken(value)
+            if value in AST.literals:
+                return LiteralToken(value)
+            if value in AST.aggregates:
+                return AggToken(value)
+
         if (value[0], value[-1]) == ("{", "}"):
             return ParamToken(value)
         try:
@@ -229,6 +251,13 @@ class Token:
 
     def _eval(self, env, flavor, *args):
         return None
+
+    @property
+    def is_var_op(self):
+        return isinstance(self, BuiltinToken) and self.value == "var"
+
+class LParen(Token):
+    "Left Parenthesis"
 
 
 class ParamToken(Token):
@@ -308,7 +337,7 @@ class VarToken(Token):
 
 
 class OpToken(Token):
-    ops = AST.builtins
+    ops = AST.builtins | AST.literals
 
     def _eval(self, env, flavor, *args):
         op = self.ops[self.value]
@@ -344,6 +373,14 @@ class BuiltinToken(OpToken):
             return bool
         else:
             return str
+
+
+class LiteralToken(OpToken):
+
+    def _eval_type(self, env, *operands):
+        if self.value == "null":
+            return None
+        return bool
 
 
 class AggToken(OpToken):

--- a/nagra/sexpr.py
+++ b/nagra/sexpr.py
@@ -117,7 +117,6 @@ class AST:
         "||": lambda *xs: " || ".join(map(str, xs)),
         # Others
         "in": lambda x, *ys: f"{x} in (%s)" % ", ".join(map(str, ys)),
-        "var": lambda x: x
     }
 
     literals = {
@@ -214,10 +213,12 @@ class Token:
         if value == "(":
             return LParen(value)
 
-        # Literals take precedence over everything except
-        # when following a var operator
-        is_prev_var_op = prev_tk and prev_tk.is_var_op
-        if not is_prev_var_op and value in AST.literals:
+        # Dot prefix force Vartoken
+        if value.startswith("."):
+            return VarToken(value.lstrip("."))
+
+        # Literals take precedence over everything else
+        if value in AST.literals:
             return LiteralToken(value)
 
         # First item should be an operator
@@ -252,9 +253,6 @@ class Token:
     def _eval(self, env, flavor, *args):
         return None
 
-    @property
-    def is_var_op(self):
-        return isinstance(self, BuiltinToken) and self.value == "var"
 
 class LParen(Token):
     "Left Parenthesis"

--- a/nagra/table.py
+++ b/nagra/table.py
@@ -272,7 +272,7 @@ class Table:
         for column in columns:
             # Escape literals (nul, true, false)
             if column in AST.literals:
-                yield f"(var {column})"
+                yield f".{column}"
                 continue
             # Handle non foreign keys
             if column not in self.foreign_keys or nk_only:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,9 @@ kitchensink_table = Table(
         "date": "date",
         "json": "json",
         "uuid": "uuid",
+        "max": "varchar",
+        "true": "varchar",
+
     },
     natural_key=["varchar"],
 )

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -11,6 +11,7 @@ def equivalent_classes(A, B):
 
     for A_field, B_field in zip(A_fields, B_fields):
         if A_field.name != B_field.name:
+            breakpoint()
             return False
         if A_field.type != B_field.type:
             return False
@@ -86,7 +87,8 @@ def test_select_with_sexp(person):
 
 def test_kitchensink(kitchensink):
     select = kitchensink.select()
-    dclass = select.to_dataclass()
+    aliases = kitchensink.columns
+    dclass = select.to_dataclass(*aliases)
 
     @dataclass
     class KitchenSink:
@@ -100,6 +102,8 @@ def test_kitchensink(kitchensink):
         date: Optional[date]
         json: Optional[dict | list]
         uuid: Optional[str]
+        max: Optional[str]
+        true: Optional[str]
 
     assert equivalent_classes(dclass, KitchenSink)
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -46,7 +46,7 @@ def test_from_pandas(transaction, kitchensink):
             "json": [{}],
             "uuid": ["F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C"],
             "max": ["max"],
-            "(var true)": ["true"],
+            "true": ["true"],
         }
     )
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -45,6 +45,8 @@ def test_from_pandas(transaction, kitchensink):
             "date": ["1970-01-01"],
             "json": [{}],
             "uuid": ["F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C"],
+            "max": ["max"],
+            "(var true)": ["true"],
         }
     )
 
@@ -64,6 +66,8 @@ def test_from_pandas(transaction, kitchensink):
             date(1970, 1, 1),
             {},
             UUID("F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C"),
+            "max",
+            "true",
         )
     else:
         assert row == (
@@ -77,6 +81,8 @@ def test_from_pandas(transaction, kitchensink):
             "1970-01-01",
             "{}",
             "F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C",
+            "max",
+            "true",
         )
 
     # SELECT

--- a/tests/test_sexpr.py
+++ b/tests/test_sexpr.py
@@ -48,11 +48,10 @@ def test_sexpr():
     ast = AST.parse(expr)
     assert str(ast.tokens) == "[<BuiltinToken is>, <LiteralToken null>, <LiteralToken true>]"
 
-    # Use var builtin to escape variables
-    expr = "(is null (var true))"
+    # Use dot prefix to escape literal
+    expr = "(is null .true))"
     ast = AST.parse(expr)
-    assert str(ast.tokens[:2]) == "[<BuiltinToken is>, <LiteralToken null>]"
-    assert str(ast.tokens[2].tokens) == "[<BuiltinToken var>, <VarToken true>]"
+    assert str(ast.tokens) == "[<BuiltinToken is>, <LiteralToken null>, <VarToken true>]"
 
     # Compare litterals
     expr = "(!= true false)"

--- a/tests/test_sexpr.py
+++ b/tests/test_sexpr.py
@@ -28,6 +28,36 @@ def test_sexpr():
     ast = AST.parse(expr)
     assert str(ast.tokens) == "[<BuiltinToken ||>, <StrToken one>, <StrToken two>]"
 
+    # With variable clashing with an aggregate
+    expr = "(max min)"
+    ast = AST.parse(expr)
+    assert str(ast.tokens) == "[<AggToken max>, <VarToken min>]"
+
+    # With lone aggregate
+    expr = "(count)"
+    ast = AST.parse(expr)
+    assert str(ast.tokens) == "[<AggToken count>]"
+
+    # With an operator sign as variable
+    expr = "(1 + 1)"
+    ast = AST.parse(expr)
+    assert str(ast.tokens) == "[<IntToken 1>, <VarToken +>, <IntToken 1>]"
+
+    # With litterals
+    expr = "(is null true)"
+    ast = AST.parse(expr)
+    assert str(ast.tokens) == "[<BuiltinToken is>, <LiteralToken null>, <LiteralToken true>]"
+
+    # Use var builtin to escape variables
+    expr = "(is null (var true))"
+    ast = AST.parse(expr)
+    assert str(ast.tokens[:2]) == "[<BuiltinToken is>, <LiteralToken null>]"
+    assert str(ast.tokens[2].tokens) == "[<BuiltinToken var>, <VarToken true>]"
+
+    # Compare litterals
+    expr = "(!= true false)"
+    ast = AST.parse(expr)
+    assert str(ast.tokens) ==  "[<BuiltinToken !=>, <LiteralToken true>, <LiteralToken false>]"
 
 def test_find_relations():
     expr = "(= ham.spam foo.bar)"

--- a/tests/test_table_select.py
+++ b/tests/test_table_select.py
@@ -41,7 +41,7 @@ def test_kitchensink_select(kitchensink):
         ';',
     ]
 
-    stm = kitchensink.select('(var true)').stm()
+    stm = kitchensink.select('.true').stm()
     res = strip_lines(stm)
     assert res == ['SELECT', '"kitchensink"."true"', 'FROM "kitchensink"', ';']
 

--- a/tests/test_table_select.py
+++ b/tests/test_table_select.py
@@ -28,6 +28,28 @@ def test_select_with_join(person):
     ]
 
 
+def test_kitchensink_select(kitchensink):
+    stm = kitchensink.select().stm()
+    res = strip_lines(stm)
+    assert res == [
+        'SELECT',
+        '"kitchensink"."varchar", "kitchensink"."bigint", "kitchensink"."float", '
+        '"kitchensink"."int", "kitchensink"."timestamp", "kitchensink"."timestamptz", '
+        '"kitchensink"."bool", "kitchensink"."date", "kitchensink"."json", '
+        '"kitchensink"."uuid", "kitchensink"."max", "kitchensink"."true"',
+        'FROM "kitchensink"',
+        ';',
+    ]
+
+    stm = kitchensink.select('(var true)').stm()
+    res = strip_lines(stm)
+    assert res == ['SELECT', '"kitchensink"."true"', 'FROM "kitchensink"', ';']
+
+    stm = kitchensink.select('true').stm()
+    res = strip_lines(stm)
+    assert res == ['SELECT', 'true', 'FROM "kitchensink"', ';']
+
+
 def test_select_clone(person):
     queries = [
         person.select("name")

--- a/tests/test_table_update.py
+++ b/tests/test_table_update.py
@@ -81,7 +81,7 @@ def test_from_pandas(transaction, kitchensink):
             "json": [{}],
             "uuid": ["F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C"],
             "max": ["max"],
-            "(var true)": ["true"],
+            "true": ["true"],
         }
     )
     ids = kitchensink.upsert().from_pandas(df)

--- a/tests/test_table_update.py
+++ b/tests/test_table_update.py
@@ -80,6 +80,8 @@ def test_from_pandas(transaction, kitchensink):
             "date": ["1970-01-01"],
             "json": [{}],
             "uuid": ["F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11C"],
+            "max": ["max"],
+            "(var true)": ["true"],
         }
     )
     ids = kitchensink.upsert().from_pandas(df)
@@ -98,6 +100,8 @@ def test_from_pandas(transaction, kitchensink):
             "date": ["1970-01-02"],
             "json": '[{"foo": "bar"}]',
             "uuid": ["F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11D"],
+            "max": ["max"],
+            "true": ["true"],
         }
     )
     kitchensink.update(*df.columns).from_pandas(df)
@@ -116,6 +120,8 @@ def test_from_pandas(transaction, kitchensink):
             date(1970, 1, 2),
             [{"foo": "bar"}],
             UUID("F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11D"),
+            "max",
+            "true",
         )
     else:
         assert row == (
@@ -129,6 +135,8 @@ def test_from_pandas(transaction, kitchensink):
             "1970-01-02",
             '[{"foo": "bar"}]',
             "F1172BD3-0A1D-422E-8ED6-8DC2D0F8C11D",
+            "max",
+            "true",
         )
 
 


### PR DESCRIPTION
Add support for table columns with reserved names, like `true` or `null`