### PR TITLE
Fix _add_column: use correct name for primary key

### DIFF
--- a/nagra/schema.py
+++ b/nagra/schema.py
@@ -257,6 +257,11 @@ class Schema:
                     continue
                 if column in db_columns.get(table.name, []):
                     continue
+                if fk_table_name := table.foreign_keys.get(column):
+                    fk_table = self.get(fk_table_name)
+                else:
+                    fk_table = None
+
                 stmt = Statement(
                     "add_column",
                     flavor=trn.flavor,
@@ -264,7 +269,7 @@ class Schema:
                     column=column,
                     col_def=ctypes[column],
                     not_null=column in table.not_null,
-                    fk_table=table.foreign_keys.get(column),
+                    fk_table=fk_table,
                     default=table.default.get(column),
                 )
                 yield stmt()

--- a/nagra/template/postgresql/add_column.sql
+++ b/nagra/template/postgresql/add_column.sql
@@ -4,5 +4,5 @@ ALTER TABLE "{{table}}"
  DEFAULT {{default}}
 {%- endif %}
 {%- if fk_table %}
- CONSTRAINT fk_{{column}} REFERENCES "{{fk_table}}"(id) {{- " ON DELETE CASCADE" if not_null else "" }};
+ CONSTRAINT fk_{{column}} REFERENCES "{{fk_table.name}}"("{{fk_table.primary_key}}") {{- " ON DELETE CASCADE" if not_null else "" }};
 {%- endif %}

--- a/nagra/template/sqlite/add_column.sql
+++ b/nagra/template/sqlite/add_column.sql
@@ -4,6 +4,6 @@ ALTER TABLE "{{table}}"
  DEFAULT {{default}}
 {%- endif %}
 {%- if fk_table %}
- CONSTRAINT fk_{{column}} REFERENCES "{{fk_table}}"(id) {{- " ON DELETE CASCADE" if not_null else "" }};
+ CONSTRAINT fk_{{column}} REFERENCES "{{fk_table.name}}"("{{fk_table.primary_key}}") {{- " ON DELETE CASCADE" if not_null else "" }};
 {%- endif %}
 


### PR DESCRIPTION
`id` was still hard-coded in the `add_column.sql` templates