### PR TITLE
Pass kw_only=True to dataclass creation to handle mix of required and optional fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@ introspecing existing tables.
 - ` Upsert.from_dict` now support dotted notation when receiving
   records.
 - Fixed bug in schema introspection for PostgreSQL for non-lowercase names
+- Fixed bug in dataclass generation in the presence of a mix
+  of required and nullable fields.
 
 
 ### 0.6 (released 2025-07-18)

--- a/nagra/select.py
+++ b/nagra/select.py
@@ -161,7 +161,7 @@ class Select:
                 fields[name] = field_def
 
         return dataclasses.make_dataclass(
-            model_name, fields=fields.values()
+            model_name, fields=fields.values(), kw_only=True
         )
 
     def to_pydantic(self, *aliases: str, model_name=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ kitchensink_table = Table(
         "blob": "blob",
     },
     natural_key=["varchar"],
+    not_null=["int"],
 )
 
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -113,7 +113,7 @@ def test_kitchensink(kitchensink):
         varchar: str
         bigint: Optional[int]
         float: Optional[float]
-        int: Optional[int]
+        int: int
         timestamp: Optional[datetime]
         timestamptz: Optional[datetime]
         bool: Optional[bool]


### PR DESCRIPTION
In the presence of a mix of optional and required fields, the dataclass generation would fail with the error below.

With `kw_only=True`, there is no restriction on the the presence of default values or not.

```
  File "/Users/sebastien.wertz/Source/nagra/nagra/select.py", line 163, in to_dataclass
    return dataclasses.make_dataclass(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        model_name, fields=fields.values()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/sebastien.wertz/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/dataclasses.py", line 1574, in make_dataclass
    return dataclass(cls, init=init, repr=repr, eq=eq, order=order,
                     unsafe_hash=unsafe_hash, frozen=frozen,
                     match_args=match_args, kw_only=kw_only, slots=slots,
                     weakref_slot=weakref_slot)
  File "/Users/sebastien.wertz/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/dataclasses.py", line 1305, in dataclass
    return wrap(cls)
  File "/Users/sebastien.wertz/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/dataclasses.py", line 1295, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
                          frozen, match_args, kw_only, slots,
                          weakref_slot)
  File "/Users/sebastien.wertz/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/dataclasses.py", line 1078, in _process_class
    _init_fn(all_init_fields,
    ~~~~~~~~^^^^^^^^^^^^^^^^^
             std_init_fields,
             ^^^^^^^^^^^^^^^^
    ...<9 lines>...
             slots,
             ^^^^^^
             )
             ^
  File "/Users/sebastien.wertz/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/dataclasses.py", line 627, in _init_fn
    raise TypeError(f'non-default argument {f.name!r} '
                    f'follows default argument {seen_default.name!r}')
TypeError: non-default argument 'int' follows default argument 'float'
```