### PR TITLE
Small fixes to pyproject and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,17 @@ To install the project in editable mode along with all the optional dependencies
 as well as the dependencies needed for development (testing, linting, ...),
 clone the project and run:
 
-    [uv ] pip install --group dev -e '.[all]'
+    [uv] pip install --group dev -e .
 
 Or, to use stock uv functionalities:
 
-    uv sync --extra all
+    uv sync
+
+To run the tests, you will need a local PostgreSQL cluster running (install it e.g. with `brew install postgresql`),
+containing a database `nagra`. You can create it using the command `createdb nagra`. 
+Then, simply run
+
+    [uv run] pytest
 
 # Miscellaneous
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,13 @@ nagra = "nagra.cli:run"
 
 [project.optional-dependencies]
 pandas = ["pandas"]
-polars = ["polars", "connectorx"]
-pg = ["psycopg"]
-all = ["nagra[pandas,polars,pg]"]
+polars = ["polars"]
+pg = ["psycopg[binary]"]
+pydantic = ["pydantic"]
+all = ["nagra[pandas,polars,pg,pydantic]"]
 
 [dependency-groups]
-dev = ["pytest", "typeguard", "ruff"]
+dev = ["nagra[all]", "pytest", "typeguard", "ruff"]
 
 [project.urls]
 Homepage = "https://github.com/b12consulting/nagra"


### PR DESCRIPTION
- Remove connectorx for polars optional dependency
- Add pydantic option
- Explicitly install all optional dependencies for development/testing (hence the new pydantic option, since the tests fail if pydantic is not installed). Another option would be to skip tests depending on which optional dependencies are installed, but at the of risks introducting bugs that the skipped tests would have caught. WDYT?
- Explain in README how to run the full test suite.