### PR TITLE
Fix select templates for joins on foreign keys in titlecase

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,12 @@
 # Changelog
 
 
-### 0.7 (to be released)
+### 0.9 (to be released)
+
+**Misc**:
+- Fixed bug in select when joining with foreign key that is not lowercase.
+
+### 0.8 (released 2025-09-24)
 
 **Operators support** S-expression module now infer operator signature
 for all infix operators, only infix ones must be explicitly

--- a/nagra/template/postgresql/select.sql
+++ b/nagra/template/postgresql/select.sql
@@ -3,8 +3,8 @@ SELECT
 FROM "{{table}}"
 
 {%- for next_table, alias, prev_table, alias_col, prev_col in joins %}
- LEFT JOIN "{{next_table}}" as {{alias}} ON (
-    {{alias}}."{{alias_col}}" = "{{prev_table}}"."{{prev_col}}"
+ LEFT JOIN "{{next_table}}" as "{{alias}}" ON (
+    "{{alias}}"."{{alias_col}}" = "{{prev_table}}"."{{prev_col}}"
  )
 {%- endfor -%}
 

--- a/nagra/template/sqlite/select.sql
+++ b/nagra/template/sqlite/select.sql
@@ -3,8 +3,8 @@ SELECT
 FROM "{{table}}"
 
 {%- for next_table, alias, prev_table, alias_col, prev_col in joins %}
- LEFT JOIN "{{next_table}}" as {{alias}} ON (
-    {{alias}}."{{alias_col}}" = "{{prev_table}}"."{{prev_col}}"
+ LEFT JOIN "{{next_table}}" as "{{alias}}" ON (
+    "{{alias}}"."{{alias_col}}" = "{{prev_table}}"."{{prev_col}}"
  )
 {%- endfor -%}
 


### PR DESCRIPTION
This fixes the following situation:

```
[Company]
primary_key = "Id"
[Company.columns]
Name = "str"

[Employee]
primary_key = "Id"
[Employee.columns]
Id = "int"
CompanyId = "int"
[Employee.foreign_keys]
CompanyId = "Company"
```

The following query:
```python
schema.get("Employee").select("CompanyId.Name")
```

Would yield the following statement:
```sql
SELECT
  "CompanyId_0"."Name"
FROM "Employee"
 LEFT JOIN "Company" as CompanyId_0 ON (
    CompanyId_0."Id" = "Employee"."CompanyId"
 )
```

(It also took me a while to realise that the select had to be done on `CompanyId.Name` and not `Company.Name`)