### PR TITLE
Fix quoting of column types in TOML schema generation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 **Misc**:
 - Fixed bug in select when joining with foreign key that is not lowercase.
+- Fixed TOML schema generation: column types should be quoted.
 
 ### 0.8 (released 2025-09-24)
 

--- a/nagra/template/misc/schema.toml
+++ b/nagra/template/misc/schema.toml
@@ -2,7 +2,7 @@
 natural_key = [{{ table.natural_key | map('autoquote') |join(', ') }}]
 [{{table.name}}.columns]
 {% for col_name, col in table.columns.items() -%}
-{{col_name}} = {{col.dtype}}
+{{col_name}} = "{{col.dtype}}"
 {% endfor -%}
 {% if table.foreign_keys -%}
 [{{table.name}}.foreign_keys]


### PR DESCRIPTION
Fix the column types in automatic TOML schema generation: from
```
[Table.Columns]
column = str
```
to
```
[Table.Columns]
column = "str"
```